### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "multinite-web-script-compiler"
 description = "A compiler for the multinite web script language."
 homepage = "https://multinite.com"
+repository = "https://github.com/Multinite/multinite-web-compiler"
 keywords = ["mws", "multinite", "web", "script", "compiler"]
 version = "1.1.1"
 edition = "2021"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.